### PR TITLE
Add ability to specify OAuth2 authentication modes including Internal, LDAP, SAML, and Windows.

### DIFF
--- a/CherwellAPI/Cache.py
+++ b/CherwellAPI/Cache.py
@@ -31,9 +31,13 @@ class ObjectCache:
 
         The Cherwell REST API client key used for authorisation
 
+    auth_mode : str
+
+        The Cherwell authentication mode used to retrieve the token. Supported modes are Internal (default), LDAP, SAML, and Windows.
+
     """
 
-    def __init__(self, base_uri, api_key):
+    def __init__(self, base_uri, api_key, auth_mode):
 
         # Start the cache
         self.cache = {}
@@ -41,10 +45,11 @@ class ObjectCache:
         # add the base uri and other attributes
         self.cache["base_uri"] = base_uri
         self.cache["api_key"] = api_key
+        self.cache["auth_mode"] = auth_mode
 
         # Add various uri's for accessing the api
         self.cache["uris"] = {
-            "Token": "{0}/CherwellAPI/token?auth_mode=Windowsl&api_key={1}".format(base_uri, api_key),
+            "Token": "{0}/CherwellAPI/token?auth_mode={1}&api_key={2}".format(base_uri, auth_mode, api_key),
             "BusinessObjectID": "{0}/CherwellAPI/api/V1/getbusinessobjectsummary/busobname/".format(base_uri),
             "BusinessObjectTemplate": "{0}/CherwellAPI/api/V1/GetBusinessObjectTemplate/".format(base_uri),
             "BusinessObjectSummary": "{0}/CherwellAPI/api/V1/getbusinessobjectsummary/busobname/".format(base_uri),

--- a/CherwellAPI/Cache.py
+++ b/CherwellAPI/Cache.py
@@ -44,7 +44,7 @@ class ObjectCache:
 
         # Add various uri's for accessing the api
         self.cache["uris"] = {
-            "Token": "{0}/CherwellAPI/token?auth_type=Internal&api_key={1}".format(base_uri, api_key),
+            "Token": "{0}/CherwellAPI/token?auth_mode=Windowsl&api_key={1}".format(base_uri, api_key),
             "BusinessObjectID": "{0}/CherwellAPI/api/V1/getbusinessobjectsummary/busobname/".format(base_uri),
             "BusinessObjectTemplate": "{0}/CherwellAPI/api/V1/GetBusinessObjectTemplate/".format(base_uri),
             "BusinessObjectSummary": "{0}/CherwellAPI/api/V1/getbusinessobjectsummary/busobname/".format(base_uri),

--- a/CherwellAPI/CherwellClient.py
+++ b/CherwellAPI/CherwellClient.py
@@ -48,19 +48,24 @@ class Connection:
         provided then this is defaulted to 'None' and a new AccessToken will be created during the first
         interaction to the Cherwell REST API
 
+    auth_mode: str
+
+        The Cherwell authentication mode to use to retrieve the token. Supported modes are Internal (default), LDAP, SAML, and Windows.
+
     https_verify : bool
 
         Flag set to verify SSL Certificates during requests API Calls
 
     """
 
-    def __init__(self, base_uri="", client_key="", username="", password="", cache=None, token=None, https_verify=False):
+    def __init__(self, base_uri="", client_key="", username="", password="", auth_mode="Internal", cache=None, token=None, https_verify=False):
 
         """ Connection instance initialisation """
 
         # Set the values we need that were passed in
         self.uri = base_uri
         self.username = username
+        self.auth_mode = auth_mode
         if not password or not client_key:
             try:
                 self.client_key = CherwellCredentials.decrypt_message("cherwell_api_key")
@@ -78,7 +83,7 @@ class Connection:
             self.cache = cache
         else:
             # We don't have a saved cache object - instantiate a new one
-            self.cache = ObjectCache(self.uri, self.client_key)
+            self.cache = ObjectCache(self.uri, self.client_key, self.auth_mode)
 
         if token is not None and isinstance(token, AccessToken):
 

--- a/CherwellAPI/CherwellClient.py
+++ b/CherwellAPI/CherwellClient.py
@@ -58,7 +58,7 @@ class Connection:
 
     """
 
-    def __init__(self, base_uri="", client_key="", username="", password="", auth_mode="Internal", cache=None, token=None, https_verify=False):
+    def __init__(self, base_uri="", client_key="", username="", password="", cache=None, token=None, https_verify=False, auth_mode="Internal"):
 
         """ Connection instance initialisation """
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Base Functionality Included
 
 The modules also cater for caching of commonly used items such as templates, summaries and business object id's as well as self-managing the expiry and refreshing of the Bearer token used for authorisation. Additionally Tokens can be cached and reused.
 
-This fork alters the auth mechanism used. The mainline CherwellAPI uses auth_type=internal. This module uses auth_mode=Windows.
-
 Encrypting the password and client_key
 ======================================
 
@@ -200,11 +198,22 @@ for business_object in business_objects:
 
 ```
 
-For more examples, refer to our GitHub project [here](https://github.com/bwittenburg/CherwellAPI/tree/master/Examples).
+Instantiating a connection using alternative authentication methods
+=================================
 
-Full source code can be found [here](https://github.com/bwittenburg/CherwellAPI).
+By default this module will use internal Cherwell authentication. Cherwell supports Internal, LDAP, SAML, and Windows authentication modes. To specify a method other than Internal, add the desired method to the Cherwell client connection:
 
-This project was created by Streamline Partners, and they deserve credit for the great work they put into this module.
+```python
+from CherwellAPI import CherwellClient
+  
+cherwell_client = CherwellClient.Connection(<base_uri>,<api_key>,<username>,<password>,<auth_mode>)  
+```
+*Replace the parameters between '<>' with appropriate values from your own Cherwell instance.*
+
+For more examples, refer to our GitHub project [here](https://github.com/streamline-partners/CherwellAPI/tree/master/Examples).
+
+Full source code can be found [here](https://github.com/streamline-partners/CherwellAPI).
+
 To find out more about Streamline Partners and how we could assist you with future projects, click [here](http://www.streamlinepartners.com.au/)
 
   

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Base Functionality Included
 
 The modules also cater for caching of commonly used items such as templates, summaries and business object id's as well as self-managing the expiry and refreshing of the Bearer token used for authorisation. Additionally Tokens can be cached and reused.
 
+This fork alters the auth mechanism used. The mainline CherwellAPI uses auth_type=internal. This module uses auth_mode=Windows.
+
 Encrypting the password and client_key
 ======================================
 
@@ -198,10 +200,11 @@ for business_object in business_objects:
 
 ```
 
-For more examples, refer to our GitHub project [here](https://github.com/streamline-partners/CherwellAPI/tree/master/Examples).
+For more examples, refer to our GitHub project [here](https://github.com/bwittenburg/CherwellAPI/tree/master/Examples).
 
-Full source code can be found [here](https://github.com/streamline-partners/CherwellAPI).
+Full source code can be found [here](https://github.com/bwittenburg/CherwellAPI).
 
+This project was created by Streamline Partners, and they deserve credit for the great work they put into this module.
 To find out more about Streamline Partners and how we could assist you with future projects, click [here](http://www.streamlinepartners.com.au/)
 
   


### PR DESCRIPTION
This adds support for specifying authentication modes when connecting to Cherwell. The default method of Internal is retained. Other methods may be specified when initializing the CherwellClient.Connection.

e.g. for Windows:
cherwell_client = CherwellClient.Connection(base_uri, api_key, username, password, "Windows")

